### PR TITLE
GitHub username is based on provided token

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ Aplikace musí podporovat zabezpečení pomocí webhook secret (viz dále).
 Na adrese `/` se při požadavku GET bude nacházet jednoduchá HTML stránka,
 ze které bude jasné, jaká pravidla platí a jaký uživatel bude štítky nastavovat.
 Uživatelské jméno se na stránce zobrazí podle použitého tokenu,
-není zadrátované do kódu apliakce nebo šablony.
+není zadrátované do kódu aplikace nebo šablony.
 
 Musíte využít šablonu.
 Nebudeme hodnotit vzhled stránky,

--- a/README.adoc
+++ b/README.adoc
@@ -33,6 +33,8 @@ Aplikace musí podporovat zabezpečení pomocí webhook secret (viz dále).
 
 Na adrese `/` se při požadavku GET bude nacházet jednoduchá HTML stránka,
 ze které bude jasné, jaká pravidla platí a jaký uživatel bude štítky nastavovat.
+Uživatelské jméno se na stránce zobrazí podle použitého tokenu,
+není zadrátované do kódu apliakce nebo šablony.
 
 Musíte využít šablonu.
 Nebudeme hodnotit vzhled stránky,


### PR DESCRIPTION
I thought this was obvious, but I see far to many students
who just put their usernames there.