### PR TITLE
Add support for factory-based Flask initialization

### DIFF
--- a/test/test_web_smoke.py
+++ b/test/test_web_smoke.py
@@ -6,8 +6,17 @@ config_env = f'{config("auth.real.cfg")}:{config("labels.empty.cfg")}'
 
 
 def _import_app():
-    from filabel import app
-    return app
+    import filabel
+    if hasattr(filabel, 'app'):
+        return filabel.app
+    elif hasattr(filabel, 'create_app'):
+        return filabel.create_app(None)
+    else:
+        raise RuntimeError("Can't find a Flask app.\n"
+                           "Either instantiate `filabel.app` variable "
+                           "or implement `filabel.create_app(dummy)` function.\n"
+                           "See http://flask.pocoo.org/docs/1.0/patterns/appfactories/ "
+                           "for additional information.")
 
 
 def _test_app():


### PR DESCRIPTION
Flask application can be created with `create_app` [factory](http://flask.pocoo.org/docs/1.0/patterns/appfactories/). This way is preferable if we don't want to initalize the web server when invoking filabel from CL. With this change we can test programs written using any of the two approaches.