### PR TITLE
Tests - Allow Flask application subclasses

### DIFF
--- a/test/test_web_smoke.py
+++ b/test/test_web_smoke.py
@@ -30,7 +30,7 @@ def _test_app():
 def test_app_imports():
     with env(FILABEL_CONFIG=config_env):
         app = _import_app()
-        assert type(app) == flask.Flask
+        assert isinstance(app, flask.Flask)
 
 
 def test_app_get_has_username():


### PR DESCRIPTION
This change allows the use of Flask application subclassing. It is a quite convenient feature of the Flask framework, but tests check against type equality and thus disallow the use of this feature.